### PR TITLE
Add dark mode with smart invert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ go build -o docviewer . && mv docviewer ~/bin/
 - `b` - Back to file list
 - `/` - Search, `n`/`N` - next/prev result
 - `t` - Toggle text/image mode
+- `i` - Toggle dark mode (smart invert)
 - `f` - Cycle fit modes (height → width → auto)
 - `+`/`-` - Manual zoom (10% to 200%)
 - `r` - Refresh cell size (after resolution/monitor change)

--- a/display.go
+++ b/display.go
@@ -127,9 +127,9 @@ func (d *DocumentViewer) displayTextPage(pageNum, termWidth, termHeight int) {
 	reserved := 2
 	available := termHeight - reserved
 
-	// Dark mode: white text on black background
-	if d.darkMode {
-		fmt.Print("\033[37;40m") // white fg, black bg
+	// Dark mode: white text on dark gray background
+	if d.darkMode != "" {
+		fmt.Print("\033[38;2;255;255;255m\033[48;2;30;30;30m")
 	}
 
 	row := 1
@@ -138,7 +138,7 @@ func (d *DocumentViewer) displayTextPage(pageNum, termWidth, termHeight int) {
 			break
 		}
 		fmt.Printf("\033[%d;1H", row)
-		if d.darkMode {
+		if d.darkMode != "" {
 			fmt.Printf("\033[K  %s", d.highlightSearchMatches(line))
 		} else {
 			fmt.Printf("  %s", d.highlightSearchMatches(line))
@@ -150,7 +150,7 @@ func (d *DocumentViewer) displayTextPage(pageNum, termWidth, termHeight int) {
 	}
 	for row <= available {
 		fmt.Printf("\033[%d;1H", row)
-		if d.darkMode {
+		if d.darkMode != "" {
 			fmt.Print("\033[K")
 		} else {
 			fmt.Print(strings.Repeat(" ", termWidth))
@@ -158,7 +158,7 @@ func (d *DocumentViewer) displayTextPage(pageNum, termWidth, termHeight int) {
 		row++
 	}
 
-	if d.darkMode {
+	if d.darkMode != "" {
 		fmt.Print("\033[0m") // reset colors
 	}
 	fmt.Printf("\033[%d;1H", termHeight-1)
@@ -306,8 +306,11 @@ func (d *DocumentViewer) displayPageInfo(pageNum, termWidth int, contentType str
 		scaleIndicator = fmt.Sprintf(" [%.0f%%]", d.scaleFactor*100)
 	}
 	darkIndicator := ""
-	if d.darkMode {
+	switch d.darkMode {
+	case "smart":
 		darkIndicator = " [dark]"
+	case "invert":
+		darkIndicator = " [dark:inv]"
 	}
 	searchIndicator := ""
 	if d.searchQuery != "" {
@@ -499,7 +502,8 @@ func (d *DocumentViewer) showHelp(inputChan <-chan byte) {
 	fmt.Println("Display:")
 	fmt.Println("  t                   - Toggle view mode (auto/text/image)")
 	fmt.Println("  f                   - Cycle fit mode (height/width/auto)")
-	fmt.Println("  i                   - Toggle dark mode (smart invert)")
+	fmt.Println("  i                   - Toggle dark mode (smart invert, preserves hue)")
+	fmt.Println("  D                   - Toggle dark mode (simple color invert)")
 	fmt.Println("  +/-                 - Zoom in/out (10%-200%)")
 	fmt.Println("  r                   - Refresh cell size (after resolution change)")
 	fmt.Println("  d                   - Show debug info")

--- a/document.go
+++ b/document.go
@@ -40,7 +40,7 @@ type DocumentViewer struct {
 	skipClear     bool   // skip screen clear on next display (for smooth reload)
 	htmlPageWidth int    // virtual page width in points for HTML layout (wider = smaller text)
 	isReflowable  bool   // true for HTML (supports layout adjustment)
-	darkMode      bool   // smart-invert colors for dark mode
+	darkMode      string // "": off, "smart": HSL invert, "invert": simple RGB invert
 }
 
 func NewDocumentViewer(path string) *DocumentViewer {
@@ -573,7 +573,17 @@ func (d *DocumentViewer) handleInput(c byte) int {
 		absPath, _ := filepath.Abs(d.path)
 		exec.Command("open", "-R", absPath).Start()
 	case 'i':
-		d.darkMode = !d.darkMode
+		if d.darkMode == "smart" {
+			d.darkMode = ""
+		} else {
+			d.darkMode = "smart"
+		}
+	case 'D':
+		if d.darkMode == "invert" {
+			d.darkMode = ""
+		} else {
+			d.darkMode = "invert"
+		}
 	case 'd':
 		// Debug: show detected dimensions
 		return -4 // signal: show debug info

--- a/document.go
+++ b/document.go
@@ -40,6 +40,7 @@ type DocumentViewer struct {
 	skipClear     bool   // skip screen clear on next display (for smooth reload)
 	htmlPageWidth int    // virtual page width in points for HTML layout (wider = smaller text)
 	isReflowable  bool   // true for HTML (supports layout adjustment)
+	darkMode      bool   // smart-invert colors for dark mode
 }
 
 func NewDocumentViewer(path string) *DocumentViewer {
@@ -571,6 +572,8 @@ func (d *DocumentViewer) handleInput(c byte) int {
 	case 'O':
 		absPath, _ := filepath.Abs(d.path)
 		exec.Command("open", "-R", absPath).Start()
+	case 'i':
+		d.darkMode = !d.darkMode
 	case 'd':
 		// Debug: show detected dimensions
 		return -4 // signal: show debug info

--- a/document.go
+++ b/document.go
@@ -36,8 +36,10 @@ type DocumentViewer struct {
 	cellHeight   float64   // cached cell height in pixels
 	lastTermCols int       // last known terminal columns (for change detection)
 	lastTermRows int       // last known terminal rows (for change detection)
-	fifoPath     string    // path to FIFO for external page jump commands
-	skipClear    bool      // skip screen clear on next display (for smooth reload)
+	fifoPath      string // path to FIFO for external page jump commands
+	skipClear     bool   // skip screen clear on next display (for smooth reload)
+	htmlPageWidth int    // virtual page width in points for HTML layout (wider = smaller text)
+	isReflowable  bool   // true for HTML (supports layout adjustment)
 }
 
 func NewDocumentViewer(path string) *DocumentViewer {
@@ -46,13 +48,17 @@ func NewDocumentViewer(path string) *DocumentViewer {
 
 	tempDir := filepath.Join(os.TempDir(), fmt.Sprintf("docviewer_%d", time.Now().UnixNano()))
 
-	return &DocumentViewer{
-		path:        path,
-		fileType:    fileType,
-		tempDir:     tempDir,
-		fitMode:     "height", // default: fit to height
-		scaleFactor: 1.0,
+	dv := &DocumentViewer{
+		path:         path,
+		fileType:     fileType,
+		tempDir:      tempDir,
+		fitMode:      "height", // default: fit to height
+		scaleFactor:  1.0,
+		htmlPageWidth: 1000, // default: wider than A4 (595pt) so text appears smaller
+		isReflowable: fileType == "html" || fileType == "htm",
 	}
+
+	return dv
 }
 
 func (d *DocumentViewer) Open() error {
@@ -61,6 +67,11 @@ func (d *DocumentViewer) Open() error {
 		return fmt.Errorf("error opening %s: %v", d.fileType, err)
 	}
 	d.doc = doc
+
+	// For reflowable documents (HTML), set the layout with our font size
+	if d.isReflowable {
+		d.applyHTMLLayout()
+	}
 
 	// Store modification time for auto-reload
 	if info, err := os.Stat(d.path); err == nil {
@@ -72,6 +83,45 @@ func (d *DocumentViewer) Open() error {
 		return fmt.Errorf("no pages with extractable content found")
 	}
 	return nil
+}
+
+// applyHTMLLayout calls fz_layout_document to set page width for HTML files.
+// Wider page = more text per line = text appears smaller when scaled to terminal.
+func (d *DocumentViewer) applyHTMLLayout() {
+	// Height proportional to width (A4 ratio ~1.414), em=12 (MuPDF default)
+	h := float64(d.htmlPageWidth) * 1.414
+	layoutDocument(d.doc, float64(d.htmlPageWidth), h, 12)
+	d.findContentPages()
+}
+
+// adjustHTMLZoom changes the page width and preserves approximate scroll position.
+func (d *DocumentViewer) adjustHTMLZoom(delta int) {
+	// Remember approximate position as fraction through document
+	frac := 0.0
+	if len(d.textPages) > 1 {
+		frac = float64(d.currentPage) / float64(len(d.textPages)-1)
+	}
+
+	d.htmlPageWidth += delta
+	if d.htmlPageWidth < 200 {
+		d.htmlPageWidth = 200
+	}
+	if d.htmlPageWidth > 3000 {
+		d.htmlPageWidth = 3000
+	}
+
+	d.applyHTMLLayout()
+
+	// Restore approximate position
+	if len(d.textPages) > 1 {
+		d.currentPage = int(frac*float64(len(d.textPages)-1) + 0.5)
+	}
+	if d.currentPage >= len(d.textPages) {
+		d.currentPage = len(d.textPages) - 1
+	}
+	if d.currentPage < 0 {
+		d.currentPage = 0
+	}
 }
 
 func (d *DocumentViewer) findContentPages() {
@@ -393,7 +443,7 @@ func (d *DocumentViewer) checkAndReload() bool {
 			lastSize = newInfo.Size()
 		}
 
-		// Suppress stderr during PDF open
+		// Suppress stderr during document open
 		savedPage := d.currentPage
 		savedStderr, _ := syscall.Dup(2)
 		devNull, _ := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
@@ -422,7 +472,11 @@ func (d *DocumentViewer) checkAndReload() bool {
 		oldPage := d.currentPage
 
 		d.doc = doc
-		d.findContentPages()
+		if d.isReflowable {
+			d.applyHTMLLayout()
+		} else {
+			d.findContentPages()
+		}
 
 		if len(d.textPages) == 0 {
 			// New doc is invalid/corrupted, keep old one
@@ -488,14 +542,24 @@ func (d *DocumentViewer) handleInput(c byte) int {
 	case 'N':
 		d.prevSearchHit()
 	case '+', '=':
-		d.scaleFactor += 0.1
-		if d.scaleFactor > 2.0 {
-			d.scaleFactor = 2.0
+		if d.isReflowable {
+			// Narrower page = larger text
+			d.adjustHTMLZoom(-100)
+		} else {
+			d.scaleFactor += 0.1
+			if d.scaleFactor > 2.0 {
+				d.scaleFactor = 2.0
+			}
 		}
 	case '-', '_':
-		d.scaleFactor -= 0.1
-		if d.scaleFactor < 0.1 {
-			d.scaleFactor = 0.1
+		if d.isReflowable {
+			// Wider page = smaller text
+			d.adjustHTMLZoom(100)
+		} else {
+			d.scaleFactor -= 0.1
+			if d.scaleFactor < 0.1 {
+				d.scaleFactor = 0.1
+			}
 		}
 	case 'r':
 		// Refresh cell size (useful after resolution/monitor change)

--- a/filesearch.go
+++ b/filesearch.go
@@ -118,7 +118,7 @@ func (fs *FileSearcher) scanDirectory(dir string, maxDepth int) []string {
 			results = append(results, subResults...)
 		} else {
 			ext := strings.ToLower(filepath.Ext(entry.Name()))
-			if ext == ".pdf" || ext == ".epub" || ext == ".docx" {
+			if ext == ".pdf" || ext == ".epub" || ext == ".docx" || ext == ".html" || ext == ".htm" {
 				results = append(results, fullPath)
 			}
 		}

--- a/image.go
+++ b/image.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"image"
+	"image/color"
 	"image/png"
+	"math"
 	"os"
 	"path/filepath"
 
@@ -104,7 +107,13 @@ func (d *DocumentViewer) savePageAsImage(pageNum, termWidth, termHeight int) (st
 		return "", 0, 0, err
 	}
 
-	bounds := img.Bounds()
+	// Apply dark mode (smart invert: flip lightness, preserve hue)
+	var finalImg image.Image = img
+	if d.darkMode {
+		finalImg = smartInvert(img)
+	}
+
+	bounds := finalImg.Bounds()
 	actualWidth := bounds.Dx()
 	actualHeight := bounds.Dy()
 
@@ -124,7 +133,7 @@ func (d *DocumentViewer) savePageAsImage(pageNum, termWidth, termHeight int) (st
 	}
 	defer file.Close()
 
-	err = png.Encode(file, img)
+	err = png.Encode(file, finalImg)
 	if err != nil {
 		os.Remove(imagePath)
 		return "", 0, 0, err
@@ -151,4 +160,101 @@ func (d *DocumentViewer) renderWithTermImg(imagePath string, estimatedLines int,
 	}
 
 	return estimatedLines
+}
+
+// smartInvert inverts lightness while preserving hue and saturation.
+// White backgrounds become black, black text becomes white, colors keep their hue.
+func smartInvert(src image.Image) image.Image {
+	bounds := src.Bounds()
+	dst := image.NewRGBA(bounds)
+
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, g, b, a := src.At(x, y).RGBA()
+			r8 := float64(r>>8) / 255.0
+			g8 := float64(g>>8) / 255.0
+			b8 := float64(b>>8) / 255.0
+
+			h, s, l := rgbToHSL(r8, g8, b8)
+			l = 1.0 - l // invert lightness
+			nr, ng, nb := hslToRGB(h, s, l)
+
+			dst.Set(x, y, color.RGBA{
+				R: uint8(nr * 255),
+				G: uint8(ng * 255),
+				B: uint8(nb * 255),
+				A: uint8(a >> 8),
+			})
+		}
+	}
+	return dst
+}
+
+func rgbToHSL(r, g, b float64) (h, s, l float64) {
+	max := math.Max(r, math.Max(g, b))
+	min := math.Min(r, math.Min(g, b))
+	l = (max + min) / 2
+
+	if max == min {
+		return 0, 0, l
+	}
+
+	d := max - min
+	if l > 0.5 {
+		s = d / (2.0 - max - min)
+	} else {
+		s = d / (max + min)
+	}
+
+	switch max {
+	case r:
+		h = (g - b) / d
+		if g < b {
+			h += 6
+		}
+	case g:
+		h = (b-r)/d + 2
+	case b:
+		h = (r-g)/d + 4
+	}
+	h /= 6
+	return
+}
+
+func hslToRGB(h, s, l float64) (r, g, b float64) {
+	if s == 0 {
+		return l, l, l
+	}
+
+	var q float64
+	if l < 0.5 {
+		q = l * (1 + s)
+	} else {
+		q = l + s - l*s
+	}
+	p := 2*l - q
+
+	r = hueToRGB(p, q, h+1.0/3.0)
+	g = hueToRGB(p, q, h)
+	b = hueToRGB(p, q, h-1.0/3.0)
+	return
+}
+
+func hueToRGB(p, q, t float64) float64 {
+	if t < 0 {
+		t++
+	}
+	if t > 1 {
+		t--
+	}
+	if t < 1.0/6.0 {
+		return p + (q-p)*6*t
+	}
+	if t < 1.0/2.0 {
+		return q
+	}
+	if t < 2.0/3.0 {
+		return p + (q-p)*(2.0/3.0-t)*6
+	}
+	return p
 }

--- a/layout.go
+++ b/layout.go
@@ -1,0 +1,26 @@
+package main
+
+/*
+// fz_layout_document is provided by the MuPDF library linked via go-fitz.
+// It controls the page layout for reflowable documents (HTML, EPUB).
+// w = page width in points, h = page height in points, em = base font size in points.
+extern void fz_layout_document(void *ctx, void *doc, float w, float h, float em);
+*/
+import "C"
+
+import (
+	"reflect"
+	"unsafe"
+
+	"github.com/gen2brain/go-fitz"
+)
+
+// layoutDocument calls MuPDF's fz_layout_document to control page layout
+// for reflowable documents (HTML, EPUB). The em parameter controls the
+// base font size in points (default is ~12pt).
+func layoutDocument(doc *fitz.Document, w, h, em float64) {
+	v := reflect.ValueOf(doc).Elem()
+	ctx := unsafe.Pointer(v.Field(0).Pointer())
+	docPtr := unsafe.Pointer(v.Field(2).Pointer())
+	C.fz_layout_document(ctx, docPtr, C.float(w), C.float(h), C.float(em))
+}

--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ KEYBOARD SHORTCUTS:
     Display:
         t                        Toggle view mode (auto/text/image)
         f                        Cycle fit modes (height/width/auto)
+        i                        Toggle dark mode (smart invert)
         +, =                     Zoom in
         -                        Zoom out
         r                        Refresh display (re-detect cell size)

--- a/main.go
+++ b/main.go
@@ -76,8 +76,8 @@ func main() {
 		}
 
 		ext := strings.ToLower(filepath.Ext(filePath))
-		if ext != ".pdf" && ext != ".epub" && ext != ".docx" {
-			fmt.Printf("Unsupported file format: %s\nSupported formats: .pdf, .epub, .docx\n", ext)
+		if ext != ".pdf" && ext != ".epub" && ext != ".docx" && ext != ".html" && ext != ".htm" {
+			fmt.Printf("Unsupported file format: %s\nSupported formats: .pdf, .epub, .docx, .html\n", ext)
 			return
 		}
 
@@ -111,7 +111,7 @@ OPTIONS:
     -v, --version    Show version
 
 SUPPORTED FORMATS:
-    PDF, EPUB, DOCX
+    PDF, EPUB, DOCX, HTML
 
 KEYBOARD SHORTCUTS:
     Navigation:
@@ -154,7 +154,7 @@ func selectFileWithPickerInDir(dir string) (string, error) {
 	}
 	allFiles := searcher.GetAllFiles()
 	if len(allFiles) == 0 {
-		return "", fmt.Errorf("no PDF or EPUB files found in %s", dir)
+		return "", fmt.Errorf("no supported files found in %s", dir)
 	}
 	picker := NewFilePicker(searcher)
 	return picker.Run()


### PR DESCRIPTION
## Summary
- Adds dark mode toggled with `i` key (smart invert)
- Inverts lightness via HSL conversion while preserving hues — white backgrounds become black, black text becomes white, colors stay recognizable
- Works in both image rendering and text rendering modes
- Shows `[dark]` indicator in status bar when active

## Test plan
- [ ] Open a PDF, press `i` — page should render with inverted lightness (dark background, light text)
- [ ] Press `i` again — returns to normal
- [ ] Toggle to text mode (`t`), verify dark mode applies white-on-black colors
- [ ] Check colorful PDFs — hues should be preserved (blue stays blue, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)