### PR TITLE
Clarify dual dark mode controls in docs and --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A terminal-based PDF, EPUB, and DOCX viewer with fuzzy file search, high-resolut
 - **HiDPI/Retina Support**: Dynamic cell size detection for sharp rendering on high-DPI displays
 - **Auto-Reload**: Automatically reloads when the PDF changes (perfect for LaTeX compilation with `latexmk -pvc`)
 - **Fit Modes**: Toggle between height-fit, width-fit, and auto-fit modes
+- **Dark Mode Options**: Smart invert (`i`, preserves hue) and simple invert (`D`)
 - **Manual Zoom**: Adjust zoom from 10% to 200%
 - **In-Document Search**: Search for text within documents
 - **Intelligent Text Reflow**: Automatically reformats text to fit your terminal width while preserving paragraphs
@@ -41,6 +42,8 @@ A terminal-based PDF, EPUB, and DOCX viewer with fuzzy file search, high-resolut
 | `N` | Previous search result |
 | `t` | Toggle text/image/auto mode |
 | `f` | Cycle fit modes (height/width/auto) |
+| `i` | Toggle dark mode (smart invert, preserves hue) |
+| `D` | Toggle dark mode (simple invert) |
 | `+` / `=` | Zoom in |
 | `-` | Zoom out |
 | `r` | Refresh display (re-detect cell size) |

--- a/main.go
+++ b/main.go
@@ -155,7 +155,8 @@ KEYBOARD SHORTCUTS:
     Display:
         t                        Toggle view mode (auto/text/image)
         f                        Cycle fit modes (height/width/auto)
-        i                        Toggle dark mode (smart invert)
+        i                        Toggle dark mode (smart invert, preserves hue)
+        D                        Toggle dark mode (simple invert)
         +, =                     Zoom in
         -                        Zoom out
         r                        Refresh display (re-detect cell size)


### PR DESCRIPTION
## Summary
- document both dark mode shortcuts in CLI --help output
- add README feature note for smart invert and simple invert
- add README keyboard shortcut rows for i and D

## Why
Dark mode has two distinct behaviors (smart invert and simple invert). This makes the controls discoverable and consistent across runtime help and static docs.