### PR TITLE
fix: collect supported files in ScanDirectory Walk callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 docviewer
 lnreader
+.DS_Store
+pdf-cli

--- a/filesearch.go
+++ b/filesearch.go
@@ -119,6 +119,12 @@ func (fs *FileSearcher) ScanDirectory(dir string) error {
 			return nil
 		}
 
+
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext == ".pdf" || ext == ".epub" || ext == ".docx" || ext == ".html" || ext == ".htm" {
+			files = append(files, path)
+		}
+
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
Problem
When opening the file picker (e.g. ./pdf-cli or ./pdf-cli some/dir), it always showed “no supported files” even when the directory contained PDFs or other supported documents.

Change
In ScanDirectory, the filepath.Walk callback now:

For each non-directory entry, checks the extension (.pdf, .epub, .docx, .html, .htm) and appends the path to files.